### PR TITLE
fix: config directory detection when XDG_CONFIG_HOME is unset

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/user"
 	"path/filepath"
 
 	"github.com/invopop/jsonschema"
@@ -283,10 +282,17 @@ func GetPath() string {
 		return filepath.Join(xdgHome, "kat", "config.yaml")
 	}
 
-	usr, err := user.Current()
-	if err != nil && usr != nil {
-		return filepath.Join(usr.HomeDir, ".config", "kat", "config.yaml")
+	usrHome, err := os.UserHomeDir()
+	if err == nil && usrHome != "" {
+		return filepath.Join(usrHome, ".config", "kat", "config.yaml")
 	}
 
-	return filepath.Join(os.TempDir(), "kat", "config.yaml")
+	tmpConfig := filepath.Join(os.TempDir(), "kat", "config.yaml")
+
+	slog.Warn("could not determine user config directory, using temp path for config",
+		slog.String("path", tmpConfig),
+		slog.Any("error", fmt.Errorf("$XDG_CONFIG_HOME is unset, fall back to home directory: %w", err)),
+	)
+
+	return tmpConfig
 }


### PR DESCRIPTION
Fixes #61

My condition here was wrong, `err != nil && usr != nil` should have been `err == nil && usr != nil`

Also switches to `os.UserHomeDir()` (simpler than using os/user), adds some logging, and tests for this.