### PR TITLE
In Homebrew install section of the README, also install yq

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Together, these deliver a seamless development experience that maintains context
 ### Homebrew
 
 ```sh
-brew install macropower/tap/kat
+brew install macropower/tap/kat yq
 ```
 
 ### Go


### PR DESCRIPTION
Since `yq` is needed in order for `kat` to actually work.