### PR TITLE
feat!: add `extraArgs` for CLI overrides, make `args` immutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,12 @@ Render a project in a specific directory using the `ks` profile:
 kat ./example/kustomize ks
 ```
 
-Render a project and override the profile arguments:
+Render a project with custom profile arguments:
 
 ```sh
-kat ./example/kustomize ks -- build . --enable-helm
+kat ./example/kustomize ks -- --enable-helm
+
+kat ./example/helm helm -- -g -f prod-values.yaml
 ```
 
 Render a project with command passthrough:
@@ -276,6 +278,7 @@ rules:
 
 - `command` (required): The command to execute
 - `args`: Arguments to pass to the command
+- `extraArgs`: Arguments that can be overridden from the CLI
 - `env`: List of environment variables for the command
 - `envFrom`: List of sources for environment variables
 - `source`: Define which files to watch for changes (when watch is enabled)
@@ -296,7 +299,8 @@ Profile `source` expressions use list-returning CEL expressions with the same va
 profiles:
   helm:
     command: helm
-    args: [template, ., --generate-name]
+    args: [template, .]
+    extraArgs: [-g]
     source: >-
       files.filter(f, pathExt(f) in [".yaml", ".yml", ".tpl"])
     envFrom:
@@ -371,7 +375,8 @@ rules:
 profiles:
   helm:
     command: helm
-    args: [template, ., --generate-name]
+    args: [template, .]
+    extraArgs: [-g]
     source: >-
       files.filter(f,
         pathExt(f) in [".yaml", ".yml", ".tpl"])
@@ -402,7 +407,8 @@ profiles:
 
   helm:
     command: helm
-    args: [template, ., --generate-name]
+    args: [template, .]
+    extraArgs: [-g]
     source: >-
       files.filter(f, pathExt(f) in [".yaml", ".yml", ".tpl"])
     envFrom:

--- a/cmd/kat/main.go
+++ b/cmd/kat/main.go
@@ -33,14 +33,14 @@ Examples:
 	# kat a file or directory path
 	kat ./example/kustomize
 
+	# Watch for changes and reload
+	kat ./example/helm --watch
+
 	# Force using the "ks" profile (defined in config)
 	kat ./example/kustomize ks
 
-	# Override the "ks" profile arguments
-	kat ./example/kustomize ks -- build . --enable-helm
-
-	# Watch for changes and reload
-	kat ./example/helm --watch
+	# Set the "helm" profile's extra arguments
+	kat ./example/helm helm -- -g -f prod-values.yaml
 
 	# kat a file or stdin directly (disables rendering engine)
 	cat ./example/kustomize/resources.yaml | kat -f -
@@ -215,14 +215,14 @@ func getProfile(cfg *config.Config, cmd string, args []string) (*profile.Profile
 
 		var err error
 
-		p, err = profile.New(cmd, profile.WithArgs(args...))
+		p, err = profile.New(cmd, profile.WithExtraArgs(args...))
 		if err != nil {
 			return nil, fmt.Errorf("create profile: %w", err)
 		}
 	} else if len(args) > 0 {
 		slog.Debug("overwriting profile arguments", slog.String("name", cmd))
 
-		p.Command.Args = args
+		p.ExtraArgs = args
 	}
 
 	return p, nil

--- a/pkg/command/config.go
+++ b/pkg/command/config.go
@@ -48,7 +48,8 @@ var (
 				),
 			)),
 		"helm": profile.MustNew("helm",
-			profile.WithArgs("template", ".", "--generate-name"),
+			profile.WithArgs("template", "."),
+			profile.WithExtraArgs("-g"),
 			profile.WithSource(filterHelmFiles),
 			profile.WithEnvFrom([]execs.EnvFromSource{
 				{

--- a/pkg/config/config.v1beta1.json
+++ b/pkg/config/config.v1beta1.json
@@ -22,7 +22,7 @@
                       },
                       "type": "array",
                       "title": "Arguments",
-                      "description": "Args contains the command line arguments.\n\nCommand.Args: https://pkg.go.dev/github.com/macropower/kat/pkg/execs#Command"
+                      "description": "Args contains the immutable command line arguments.\n\nCommand.Args: https://pkg.go.dev/github.com/macropower/kat/pkg/execs#Command"
                     },
                     "env": {
                       "items": {
@@ -134,7 +134,7 @@
                       },
                       "type": "array",
                       "title": "Arguments",
-                      "description": "Args contains the command line arguments.\n\nCommand.Args: https://pkg.go.dev/github.com/macropower/kat/pkg/execs#Command"
+                      "description": "Args contains the immutable command line arguments.\n\nCommand.Args: https://pkg.go.dev/github.com/macropower/kat/pkg/execs#Command"
                     },
                     "env": {
                       "items": {
@@ -246,7 +246,7 @@
                       },
                       "type": "array",
                       "title": "Arguments",
-                      "description": "Args contains the command line arguments.\n\nCommand.Args: https://pkg.go.dev/github.com/macropower/kat/pkg/execs#Command"
+                      "description": "Args contains the immutable command line arguments.\n\nCommand.Args: https://pkg.go.dev/github.com/macropower/kat/pkg/execs#Command"
                     },
                     "env": {
                       "items": {
@@ -392,7 +392,7 @@
                   },
                   "type": "array",
                   "title": "Arguments",
-                  "description": "Args contains the command line arguments.\n\nCommand.Args: https://pkg.go.dev/github.com/macropower/kat/pkg/execs#Command"
+                  "description": "Args contains the immutable command line arguments.\n\nCommand.Args: https://pkg.go.dev/github.com/macropower/kat/pkg/execs#Command"
                 },
                 "env": {
                   "items": {
@@ -542,7 +542,7 @@
             },
             "type": "array",
             "title": "Arguments",
-            "description": "Args contains the command line arguments.\n\nCommand.Args: https://pkg.go.dev/github.com/macropower/kat/pkg/execs#Command"
+            "description": "Args contains the immutable command line arguments.\n\nCommand.Args: https://pkg.go.dev/github.com/macropower/kat/pkg/execs#Command"
           },
           "env": {
             "items": {
@@ -626,6 +626,14 @@
             "type": "array",
             "title": "Environment Variables From",
             "description": "EnvFrom contains sources for inheriting environment variables.\n\nCommand.EnvFrom: https://pkg.go.dev/github.com/macropower/kat/pkg/execs#Command"
+          },
+          "extraArgs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Optional Arguments",
+            "description": "ExtraArgs contains extra arguments that can be overridden from the CLI.\nThey are appended to the Args of the Command.\n\nProfile.ExtraArgs: https://pkg.go.dev/github.com/macropower/kat/pkg/profile#Profile"
           }
         },
         "additionalProperties": false,

--- a/pkg/config/config.yaml
+++ b/pkg/config/config.yaml
@@ -31,7 +31,8 @@ profiles:
     source: >-
       files.filter(f, pathExt(f) in [".yaml", ".yml", ".tpl"])
     command: helm
-    args: [template, ., --generate-name]
+    args: [template, .]
+    extraArgs: [-g]
     # env:
     #   - name: EXAMPLE_VAR
     #     value: "true"

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -52,6 +52,9 @@ type Profile struct {
 	Source string `json:"source,omitempty" jsonschema:"title=Source"`
 	// Command contains the command execution configuration.
 	Command execs.Command `json:",inline"`
+	// ExtraArgs contains extra arguments that can be overridden from the CLI.
+	// They are appended to the Args of the Command.
+	ExtraArgs []string `json:"extraArgs,omitempty" jsonschema:"title=Optional Arguments" yaml:"extraArgs,flow,omitempty"`
 }
 
 // ProfileOpt is a functional option for configuring a Profile.
@@ -86,6 +89,14 @@ func MustNew(command string, opts ...ProfileOpt) *Profile {
 func WithArgs(args ...string) ProfileOpt {
 	return func(p *Profile) {
 		p.Command.Args = args
+	}
+}
+
+// WithExtraArgs sets extra command arguments for the profile.
+// These arguments can be overridden from the CLI.
+func WithExtraArgs(args ...string) ProfileOpt {
+	return func(p *Profile) {
+		p.ExtraArgs = args
 	}
 }
 
@@ -141,6 +152,9 @@ func (p *Profile) Build() error {
 			}
 		}
 	}
+
+	// Add extra arguments to the rendering command.
+	p.Command.SetExtraArgs(p.ExtraArgs...)
 
 	err := p.CompileSource()
 	if err != nil {


### PR DESCRIPTION
This PR adds a new field `extraArgs` to profiles. The arguments passed to a command will be `args` + `extraArgs`.

Previously, only `args` was available, and passing arguments via the CLI would override the entire `args` field.

After this change:

- `args` are immutable and cannot be changed via the CLI.
- `extraArgs` are mutable and can be overridden via the CLI (same as `args` previously).

This reduces the number of arguments you typically need to pass over the CLI. For example, to set a custom values.yaml file:

```sh
# BEFORE
kat . helm -- template . -g -f prod-values.yaml

# AFTER
kat . helm -- -g -f prod-values.yaml
```

Note that the default helm profile has changed:

```diff
  command: helm
- args: [template, ., --generate-name]
+ args: [template, .]
+ extraArgs: [-g]
```