### PR TITLE
feat: automatically write default config on launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,15 @@ kat ./example/helm > manifest.yaml
 
 ## ⚙️ Configuration
 
-You can use `kat --write-config` to generate a default configuration file at `~/.config/kat/config.yaml`. This file allows you to customize the behavior of `kat`, such as the UI style, keybindings, rules for project detection, and profiles for rendering different types of projects. This will also write a JSON schema to the same location, for use with your editor's YAML language server.
+When you first run `kat`, it will attempt to add default configuration files to `$XDG_CONFIG_HOME/kat/` (or `~/.config/kat/`). This configuration allows you to customize the behavior of `kat`, such as the UI style, keybindings, rules for project detection, and profiles for rendering different types of projects.
 
-Alternatively, you can find the default configuration file as well as JSON schemas in [pkg/config](pkg/config).
+Note that JSON schemas are also included in the configuration directory, which can be used by your editor's YAML language server.
+
+> Some of the default behavior around loading configuration can be overridden with command line flags or environment variables. See `kat --help` for details.
+
+Over time, the default configuration may change, and the schema is currently still evolving. If you want to reset your configuration to the latest defaults, you can use `kat --write-config`, which will move your existing configuration to a backup file and generate a new default configuration.
+
+> You can find the default configuration file as well as JSON schemas in [pkg/config](pkg/config).
 
 ## 🛠️ Rules and Profiles
 

--- a/cmd/kat/main.go
+++ b/cmd/kat/main.go
@@ -68,7 +68,7 @@ var cli struct {
 
 	Watch bool `help:"Watch for changes and trigger reloading." short:"w"`
 
-	WriteConfig bool `env:"-" help:"Write the configuration file to the default path."`
+	WriteConfig bool `env:"-" help:"Write the default configuration files."`
 	ShowConfig  bool `env:"-" help:"Print the active configuration and exit."`
 }
 
@@ -95,14 +95,9 @@ func main() {
 		configPath = config.GetPath()
 	}
 
-	if cli.WriteConfig {
-		err := config.WriteDefaultConfig(configPath)
-		if err != nil {
-			slog.Error("write config", slog.Any("err", err))
-			cliCtx.Fatalf(cmdInitErr)
-		}
-
-		cliCtx.Exit(0)
+	err = config.WriteDefaultConfig(configPath, cli.WriteConfig)
+	if err != nil {
+		slog.Error("write config", slog.Any("err", err))
 	}
 
 	cfgData, err := config.ReadConfig(configPath)


### PR DESCRIPTION
- On first run, attempt to write default configuration files.
- If this errors, continue to use the embedded default config.
- Change the behavior of `--write-config` to back up existing config and write the latest defaults.