### PR TITLE
fix: prevent alpha keybinds from exiting text input areas

### DIFF
--- a/e2e/golden/filter-inputs.ascii
+++ b/e2e/golden/filter-inputs.ascii
@@ -1,0 +1,345 @@
+
+   2 resources
+
+ │ nginx-deployment
+ │ apps/Deployment
+
+   example-ingress
+   networking.k8s.io/Ingress
+
+
+
+
+
+
+
+
+
+
+
+
+
+ kat unknown  static                                                               1/1  ? Help
+────────────────────────────────────────────────────────────────────────────────
+
+   Find:
+
+   nginx-deployment
+   apps/Deployment
+
+   example-ingress
+   networking.k8s.io/Ingress
+
+
+
+
+
+
+
+
+
+
+
+
+
+ kat unknown  static                                                               1/1  ? Help
+────────────────────────────────────────────────────────────────────────────────
+
+   Find: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
+
+   No results.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ kat unknown  static                                                               1/1  ? Help
+────────────────────────────────────────────────────────────────────────────────
+
+   Find: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
+
+   No results.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ kat unknown  static                                                               1/1  ? Help
+────────────────────────────────────────────────────────────────────────────────
+
+   Find: abcdefghijklmnopqrstuvwxyz !@#$%^&*()-_=+{}[]\|;':"<>?/~ ABCDEFGHIJKLMNOPQRSTU
+
+   No results.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ kat unknown  static                                                               1/1  ? Help
+────────────────────────────────────────────────────────────────────────────────
+
+   Find: fghijklmnopqrstuvwxyz !@#$%^&*()-_=+{}[]\|;':"<>?/~ ABCDEFGHIJKLMNOPQRSTUVWXYZ
+
+   No results.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ kat unknown  static                                                               1/1  ? Help
+────────────────────────────────────────────────────────────────────────────────
+
+   2 resources
+
+ │ nginx-deployment
+ │ apps/Deployment
+
+   example-ingress
+   networking.k8s.io/Ingress
+
+
+
+
+
+
+
+
+
+
+
+
+
+ kat unknown  static                                                               1/1  ? Help
+────────────────────────────────────────────────────────────────────────────────
+   1  apiVersion: apps/v1
+   2  kind: Deployment
+   3  metadata:
+   4    name: nginx-deployment
+   5    labels:
+   6      app: nginx
+   7  spec:
+   8    replicas: 3
+   9    selector:
+  10      matchLabels:
+  11        app: nginx
+  12    template:
+  13      metadata:
+  14        labels:
+  15          app: nginx
+  16      spec:
+  17        containers:
+  18          - name: nginx
+  19            image: nginx:1.14.2
+  20            ports:
+  21              - containerPort: 80
+ kat unknown  nginx-deployment                                                      0%  ? Help
+────────────────────────────────────────────────────────────────────────────────
+   1  apiVersion: apps/v1
+   2  kind: Deployment
+   3  metadata:
+   4    name: nginx-deployment
+   5    labels:
+   6      app: nginx
+   7  spec:
+   8    replicas: 3
+   9    selector:
+  10      matchLabels:
+  11        app: nginx
+  12    template:
+  13      metadata:
+  14        labels:
+  15          app: nginx
+  16      spec:
+  17        containers:
+  18          - name: nginx
+  19            image: nginx:1.14.2
+  20            ports:
+  21              - containerPort: 80
+Search:
+────────────────────────────────────────────────────────────────────────────────
+   1  apiVersion: apps/v1
+   2  kind: Deployment
+   3  metadata:
+   4    name: nginx-deployment
+   5    labels:
+   6      app: nginx
+   7  spec:
+   8    replicas: 3
+   9    selector:
+  10      matchLabels:
+  11        app: nginx
+  12    template:
+  13      metadata:
+  14        labels:
+  15          app: nginx
+  16      spec:
+  17        containers:
+  18          - name: nginx
+  19            image: nginx:1.14.2
+  20            ports:
+  21              - containerPort: 80
+Search: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
+────────────────────────────────────────────────────────────────────────────────
+   1  apiVersion: apps/v1
+   2  kind: Deployment
+   3  metadata:
+   4    name: nginx-deployment
+   5    labels:
+   6      app: nginx
+   7  spec:
+   8    replicas: 3
+   9    selector:
+  10      matchLabels:
+  11        app: nginx
+  12    template:
+  13      metadata:
+  14        labels:
+  15          app: nginx
+  16      spec:
+  17        containers:
+  18          - name: nginx
+  19            image: nginx:1.14.2
+  20            ports:
+  21              - containerPort: 80
+Search: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
+────────────────────────────────────────────────────────────────────────────────
+   1  apiVersion: apps/v1
+   2  kind: Deployment
+   3  metadata:
+   4    name: nginx-deployment
+   5    labels:
+   6      app: nginx
+   7  spec:
+   8    replicas: 3
+   9    selector:
+  10      matchLabels:
+  11        app: nginx
+  12    template:
+  13      metadata:
+  14        labels:
+  15          app: nginx
+  16      spec:
+  17        containers:
+  18          - name: nginx
+  19            image: nginx:1.14.2
+  20            ports:
+  21              - containerPort: 80
+Search: abcdefghijklmnopqrstuvwxyz !@#$%^&*()-_=+{}[]\|;':"<>?/~ ABCDEFGHIJKLMNOPQRSTUVWX
+────────────────────────────────────────────────────────────────────────────────
+   1  apiVersion: apps/v1
+   2  kind: Deployment
+   3  metadata:
+   4    name: nginx-deployment
+   5    labels:
+   6      app: nginx
+   7  spec:
+   8    replicas: 3
+   9    selector:
+  10      matchLabels:
+  11        app: nginx
+  12    template:
+  13      metadata:
+  14        labels:
+  15          app: nginx
+  16      spec:
+  17        containers:
+  18          - name: nginx
+  19            image: nginx:1.14.2
+  20            ports:
+  21              - containerPort: 80
+Search: cdefghijklmnopqrstuvwxyz !@#$%^&*()-_=+{}[]\|;':"<>?/~ ABCDEFGHIJKLMNOPQRSTUVWXYZ
+────────────────────────────────────────────────────────────────────────────────
+   1  apiVersion: apps/v1
+   2  kind: Deployment
+   3  metadata:
+   4    name: nginx-deployment
+   5    labels:
+   6      app: nginx
+   7  spec:
+   8    replicas: 3
+   9    selector:
+  10      matchLabels:
+  11        app: nginx
+  12    template:
+  13      metadata:
+  14        labels:
+  15          app: nginx
+  16      spec:
+  17        containers:
+  18          - name: nginx
+  19            image: nginx:1.14.2
+  20            ports:
+  21              - containerPort: 80
+ kat unknown  nginx-deployment                                                      0%  ? Help
+────────────────────────────────────────────────────────────────────────────────
+> cat example/kustomize/resources.yaml | ./kat - --config=pkg/config/config.yaml
+>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+────────────────────────────────────────────────────────────────────────────────

--- a/e2e/tapes/filter-inputs.tape
+++ b/e2e/tapes/filter-inputs.tape
@@ -1,0 +1,29 @@
+Hide
+  Source e2e/config.tape
+  Output e2e/golden/filter-inputs.ascii
+
+  Type "cat example/kustomize/resources.yaml | ./kat - --config=pkg/config/config.yaml" Enter
+  Sleep 6s
+Show
+
+# List filter
+Type "/"
+Type "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+Left 26
+Type ` !@#$%^&*()-_=+{}[]\|;':"<>?/~ `
+Right 26
+Escape
+
+# Pager
+Enter
+
+# Pager search
+Type "/"
+Type "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+Left 26
+Type ` !@#$%^&*()-_=+{}[]\|;':"<>?/~ `
+Right 26
+Escape
+
+# Exit
+Type "q"

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -3,6 +3,7 @@ package keys
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/muesli/reflow/ansi"
@@ -97,6 +98,7 @@ func (kb *KeyBind) StringRow(keyWidth, descWidth int) string {
 	return fmt.Sprintf("%s%s  %s%s", keys, keySpaces, truncDesc, descSpaces)
 }
 
+// Match checks if the key matches any of the keys in the binding.
 func (kb *KeyBind) Match(key string) bool {
 	for _, k := range kb.Keys {
 		if k.Code == key {
@@ -105,6 +107,15 @@ func (kb *KeyBind) Match(key string) bool {
 	}
 
 	return false
+}
+
+// IsTextInputAction checks if the key should be applied as text input.
+func IsTextInputAction(key string) bool {
+	alwaysNonInput := []string{
+		"esc", "enter", "up", "down", "pgup", "pgdown",
+	}
+
+	return !slices.Contains(alwaysNonInput, key)
 }
 
 func (kb *KeyBind) AddKey(key Key) {

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -352,6 +352,41 @@ func TestKeyBind_Match(t *testing.T) {
 	}
 }
 
+func TestKeyBind_IsInputAction(t *testing.T) {
+	t.Parallel()
+
+	tcs := map[string]struct {
+		input string
+		want  bool
+	}{
+		"accepts single letter": {
+			input: "k",
+			want:  true,
+		},
+		"accepts uppercase letter": {
+			input: "K",
+			want:  true,
+		},
+		"rejects navigation key": {
+			input: "up",
+			want:  false,
+		},
+		"accepts copy": {
+			input: "ctrl+c",
+			want:  true,
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result := keys.IsTextInputAction(tc.input)
+			assert.Equal(t, tc.want, result)
+		})
+	}
+}
+
 func TestKeyBind_AddKey(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/ui/list/keys.go
+++ b/pkg/ui/list/keys.go
@@ -177,6 +177,9 @@ func (h *KeyHandler) HandleFilteringMode(m ListModel, msg tea.Msg) (ListModel, t
 // handleFilterKeys handles key events specific to filtering mode.
 func (h *KeyHandler) handleFilterKeys(m ListModel, key string) (ListModel, tea.Cmd) {
 	switch {
+	case keys.IsTextInputAction(key):
+		return m, nil
+
 	case h.ckb.Up.Match(key),
 		h.ckb.Down.Match(key),
 		h.ckb.Next.Match(key),

--- a/pkg/ui/pager/pager.go
+++ b/pkg/ui/pager/pager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/ansi"
 	"github.com/muesli/termenv"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -243,16 +244,15 @@ func (m *PagerModel) SetSize(w, h int) {
 	// Calculate viewport dimensions.
 	viewportHeight := h - statusBarHeight
 
-	// Reserve space for search bar if in search mode.
-	if m.ViewState == StateSearching {
-		viewportHeight -= statusBarHeight // Search bar takes one line.
-	}
-
 	// Calculate help height if needed.
 	if m.ShowHelp {
 		m.helpHeight = m.helpRenderer.CalculateHelpHeight()
 		viewportHeight -= (statusBarHeight + m.helpHeight)
 	}
+
+	m.searchInput.Width = w - len(m.searchInput.Prompt) - ansi.PrintableRuneWidth(
+		m.searchInput.Prompt,
+	)
 
 	m.viewport.Width = w
 	m.viewport.Height = viewportHeight


### PR DESCRIPTION
Fixes #82

This PR prevents alpha keybinds that are also assigned to navigation actions from exiting text input areas (e.g. hjkl).

Unfortunately input handling is still all over the place in the ui package, and thus this/similar bugs probably will be easy to re-introduce somewhere until I refactor it. I've added an end-to-end test to try to prevent this from happening.