### PR TITLE
feat: add profile reload expression to filter reload events

### DIFF
--- a/pkg/config/config.v1beta1.json
+++ b/pkg/config/config.v1beta1.json
@@ -528,7 +528,12 @@
           "source": {
             "type": "string",
             "title": "Source",
-            "description": "Source contains the CEL expression source code for the profile.\n\nProfile.Source: https://pkg.go.dev/github.com/macropower/kat/pkg/profile#Profile"
+            "description": "Source is a CEL expression that determines which files should be watched by\nthis profile, when file watching is enabled. The expression has access to:\n  - `files` (list\u003cstring\u003e): All file paths in directory\n  - `dir` (string): The directory path being processed\n\nSource CEL expressions must return a list of files:\n  - `files.filter(f, pathExt(f) in [\".yaml\", \".yml\"])` - returns all YAML files\n  - `files.filter(f, pathBase(f) in [\"Chart.yaml\", \"values.yaml\"])` - returns Chart and values files\n  - `files.filter(f, pathBase(f) == \"Chart.yaml\")` - returns files named Chart.yaml\n  - `files.filter(f, !pathBase(f).matches(\".*test.*\"))` - returns non-test files\n  - `files.filter(f, pathBase(f) == \"Chart.yaml\" \u0026\u0026 yamlPath(f, \"$.apiVersion\") == \"v2\")` - returns charts with apiVersion v2\n  - `files` - unfiltered list means all files should be processed\n  - `[]` - empty list means no files should be processed\n\nIf no Source expression is provided, the profile will match all files by default.\n\nProfile.Source: https://pkg.go.dev/github.com/macropower/kat/pkg/profile#Profile"
+          },
+          "reload": {
+            "type": "string",
+            "title": "Reload",
+            "description": "Reload contains a CEL expression that is evaluated on automated reload\nevents (e.g. from watch). If the expression returns true, the reload will proceed.\nIf it returns false, the reload will be skipped. The expression has access to:\n  - `file` (string): The file path that triggered the event\n  - `fs.event` (int): The file event type, at least one of `fs.CREATE`, `fs.WRITE`, `fs.REMOVE`, `fs.RENAME`, `fs.CHMOD`\n  - `render.stage` (int): The current render stage, one of `render.STAGE_NONE`, `render.STAGE_PRE_RENDER`, `render.STAGE_RENDER`, `render.STAGE_POST_RENDER`\n  - `render.result` (string): The result of the last render operation, one of `render.RESULT_OK`, `render.RESULT_ERROR`, `render.RESULT_CANCEL`\n\nReload CEL expressions must return a boolean value:\n  - `pathBase(file) != \"kustomization.yaml\"` - skip reload for kustomization.yaml files\n  - `fs.event.has(fs.WRITE, fs.RENAME)` - reload for write or rename events\n  - `render.result != render.RESULT_CANCEL` - skip reload if the last render was canceled\n  - `render.stage \u003c render.STAGE_RENDER` - only reload if the main render stage has not started\n\nIf no Reload expression is provided, the profile will always reload on any events.\n\nProfile.Reload: https://pkg.go.dev/github.com/macropower/kat/pkg/profile#Profile"
           },
           "command": {
             "type": "string",
@@ -641,7 +646,7 @@
         "required": [
           "command"
         ],
-        "description": "Profile represents a command profile with optional source filtering.\n\nThe Source field contains a CEL expression that determines which files\nshould be processed by this profile. The expression has access to:\n  - `files` (list\u003cstring\u003e): All file paths in directory\n  - `dir` (string): The directory path being processed\n\nSource CEL expressions must return a list of files:\n  - `files.filter(f, pathExt(f) in [\".yaml\", \".yml\"])` - returns all YAML files\n  - `files.filter(f, pathBase(f) in [\"Chart.yaml\", \"values.yaml\"])` - returns Chart and values files\n  - `files.filter(f, pathBase(f) == \"Chart.yaml\")` - returns files named Chart.yaml\n  - `files.filter(f, !pathBase(f).matches(\".*test.*\")) - returns non-test files\n  - `files.filter(f, pathBase(f) == \"Chart.yaml\" \u0026\u0026 yamlPath(f, \"$.apiVersion\") == \"v2\")` - returns charts with apiVersion v2\n  - `files` - unfiltered list means all files should be processed\n  - `[]` - empty list means no files should be processed\n\nIf no Source expression is provided, the profile will use default file filtering.\n\nProfile: https://pkg.go.dev/github.com/macropower/kat/pkg/profile#Profile"
+        "description": "Profile represents a command profile.\n\nProfile: https://pkg.go.dev/github.com/macropower/kat/pkg/profile#Profile"
       },
       "type": "object",
       "title": "Profiles",

--- a/pkg/expr/expr.go
+++ b/pkg/expr/expr.go
@@ -2,27 +2,13 @@ package expr
 
 import (
 	"fmt"
-	"log/slog"
-	"math"
-	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 
-	"github.com/goccy/go-yaml"
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
 )
 
-var (
-	// Protect CEL environment creation and compilation from concurrent access.
-	celMutex sync.Mutex
-
-	// DefaultEnvironment is a shared environment instance for simple use cases.
-	// This allows multiple compilations to reuse the same environment efficiently.
-	DefaultEnvironment = MustNewEnvironment()
-)
+// Protect CEL environment creation and compilation from concurrent access.
+var celMutex sync.Mutex
 
 // Environment provides a thread-safe wrapper around a [*cel.Env].
 type Environment struct {
@@ -30,8 +16,8 @@ type Environment struct {
 }
 
 // NewEnvironment creates a new [Environment].
-func NewEnvironment() (*Environment, error) {
-	env, err := createEnvironment()
+func NewEnvironment(opts ...cel.EnvOption) (*Environment, error) {
+	env, err := createEnvironment(opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +26,8 @@ func NewEnvironment() (*Environment, error) {
 }
 
 // MustNewEnvironment creates a new [Environment] and panics on error.
-func MustNewEnvironment() *Environment {
-	env, err := NewEnvironment()
+func MustNewEnvironment(opts ...cel.EnvOption) *Environment {
+	env, err := NewEnvironment(opts...)
 	if err != nil {
 		panic(err)
 	}
@@ -50,122 +36,13 @@ func MustNewEnvironment() *Environment {
 }
 
 // ensureEnvironment creates the [*cel.Env] using the global mutex.
-func createEnvironment() (*cel.Env, error) {
+func createEnvironment(opts ...cel.EnvOption) (*cel.Env, error) {
 	celMutex.Lock()
 	defer celMutex.Unlock()
 
-	celEnv, err := cel.NewEnv(
-		cel.Variable("files", cel.ListType(cel.StringType)),
-		cel.Variable("dir", cel.StringType),
+	opts = append(opts, cel.Lib(&lib{}))
 
-		// `pathBase` returns the last element of the path.
-		// Example: files.filter(f, pathBase(f) in ["Chart.yaml", "values.yaml"]).
-		cel.Function("pathBase",
-			cel.Overload("path_base", []*cel.Type{cel.StringType}, cel.StringType,
-				cel.UnaryBinding(func(path ref.Val) ref.Val {
-					pathValue, ok := path.(types.String).Value().(string)
-					if !ok {
-						return types.NewErr("pathBase: invalid string value")
-					}
-
-					return types.String(filepath.Base(pathValue))
-				}),
-			),
-		),
-
-		// `pathDir` returns all but the last element of the path.
-		// Example: files.filter(f, pathDir(f).contains("/templates/")).
-		cel.Function("pathDir",
-			cel.Overload("path_dir", []*cel.Type{cel.StringType}, cel.StringType,
-				cel.UnaryBinding(func(path ref.Val) ref.Val {
-					pathValue, ok := path.(types.String).Value().(string)
-					if !ok {
-						return types.NewErr("pathDir: invalid string value")
-					}
-
-					return types.String(filepath.Dir(pathValue))
-				}),
-			),
-		),
-
-		// `pathExt` returns the file extension of the path.
-		// Example: files.filter(f, pathExt(f) in [".yaml", ".yml"]).
-		cel.Function("pathExt",
-			cel.Overload("path_ext", []*cel.Type{cel.StringType}, cel.StringType,
-				cel.UnaryBinding(func(path ref.Val) ref.Val {
-					pathValue, ok := path.(types.String).Value().(string)
-					if !ok {
-						return types.NewErr("pathExt: invalid string value")
-					}
-
-					return types.String(filepath.Ext(pathValue))
-				}),
-			),
-		),
-
-		// `yamlPath` reads a YAML file and extracts a value using a YAML path.
-		// Returns the value at the specified path, or null if the path doesn't exist or file can't be read.
-		// Example: files.filter(f, pathBase(f) == "Chart.yaml" && yamlPath(f, "$.apiVersion") == "v2").
-		cel.Function("yamlPath",
-			cel.Overload("yaml_path", []*cel.Type{cel.StringType, cel.StringType}, cel.DynType,
-				cel.BinaryBinding(func(filePath, yamlPathExpr ref.Val) ref.Val {
-					filePathStr, ok := filePath.(types.String).Value().(string)
-					if !ok {
-						return types.NewErr("yamlPath: invalid file path")
-					}
-
-					yamlPathStr, ok := yamlPathExpr.(types.String).Value().(string)
-					if !ok {
-						return types.NewErr("yamlPath: invalid yaml path")
-					}
-
-					logger := slog.With(
-						slog.String("file", filePathStr),
-						slog.String("yamlPath", yamlPathStr),
-					)
-
-					// Read file content.
-					//nolint:gosec // G304: Potential file inclusion via variable.
-					content, err := os.ReadFile(filePathStr)
-					if err != nil {
-						// Return null if file can't be read, don't error.
-						logger.Debug("failed to read YAML file, returning null",
-							slog.Any("error", err),
-						)
-
-						return types.NullValue
-					}
-
-					// Parse YAML path.
-					path, err := yaml.PathString(yamlPathStr)
-					if err != nil {
-						// Return null if path is invalid.
-						logger.Debug("invalid YAML path, returning null",
-							slog.Any("error", err),
-						)
-
-						return types.NullValue
-					}
-
-					// Extract value using YAML path.
-					var value any
-
-					err = path.Read(strings.NewReader(string(content)), &value)
-					if err != nil {
-						// Return null if path doesn't exist or extraction fails.
-						logger.Debug("failed to extract value from YAML, returning null",
-							slog.Any("error", err),
-						)
-
-						return types.NullValue
-					}
-
-					// Convert the extracted value to a CEL value.
-					return ConvertToCELValue(value)
-				}),
-			),
-		),
-	)
+	celEnv, err := cel.NewEnv(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create CEL environment: %w", err)
 	}
@@ -191,102 +68,4 @@ func (e *Environment) Compile(expression string) (cel.Program, error) {
 	}
 
 	return program, nil
-}
-
-// ConvertToCELValue converts a Go value to a CEL value.
-// Handles common YAML types and returns null for unsupported types.
-//
-//nolint:ireturn // Following CEL's function signature.
-func ConvertToCELValue(value any) ref.Val {
-	switch v := value.(type) {
-	case nil:
-		return types.NullValue
-
-	case bool:
-		return types.Bool(v)
-
-	case int:
-		return types.Int(v)
-
-	case int8:
-		return types.Int(int64(v))
-
-	case int16:
-		return types.Int(int64(v))
-
-	case int32:
-		return types.Int(int64(v))
-
-	case int64:
-		return types.Int(v)
-
-	case uint:
-		// Check for overflow when converting to int64.
-		if v > math.MaxInt64 {
-			return types.Double(float64(v))
-		}
-
-		return types.Int(int64(v))
-
-	case uint8:
-		return types.Int(int64(v))
-
-	case uint16:
-		return types.Int(int64(v))
-
-	case uint32:
-		return types.Int(int64(v))
-
-	case uint64:
-		// Check for overflow when converting to int64.
-		if v > math.MaxInt64 {
-			return types.Double(float64(v))
-		}
-
-		return types.Int(int64(v))
-
-	case float32:
-		return types.Double(float64(v))
-
-	case float64:
-		return types.Double(v)
-
-	case string:
-		return types.String(v)
-
-	case []any:
-		// Convert slice to CEL list.
-		celValues := make([]ref.Val, len(v))
-		for i, item := range v {
-			celValues[i] = ConvertToCELValue(item)
-		}
-
-		return types.NewDynamicList(types.DefaultTypeAdapter, celValues)
-
-	case map[any]any:
-		// Convert map to CEL map.
-		celMap := make(map[ref.Val]ref.Val)
-		for key, val := range v {
-			celKey := ConvertToCELValue(key)
-			celVal := ConvertToCELValue(val)
-			celMap[celKey] = celVal
-		}
-
-		return types.NewDynamicMap(types.DefaultTypeAdapter, celMap)
-
-	case map[string]any:
-		// Convert string map to CEL map.
-		celMap := make(map[ref.Val]ref.Val)
-		for key, val := range v {
-			celKey := types.String(key)
-			celVal := ConvertToCELValue(val)
-			celMap[celKey] = celVal
-		}
-
-		return types.NewDynamicMap(types.DefaultTypeAdapter, celMap)
-
-	default:
-		// For unsupported types, return null instead of erroring.
-		return types.NullValue
-	}
 }

--- a/pkg/expr/lib.go
+++ b/pkg/expr/lib.go
@@ -1,0 +1,331 @@
+package expr
+
+import (
+	"log/slog"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/goccy/go-yaml"
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"github.com/google/cel-go/ext"
+)
+
+type lib struct{}
+
+func (lib) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		ext.Math(),
+		ext.Strings(),
+		ext.Lists(),
+
+		cel.Constant("fs.CREATE", types.IntType, types.Int(fsnotify.Create)),
+		cel.Constant("fs.REMOVE", types.IntType, types.Int(fsnotify.Remove)),
+		cel.Constant("fs.WRITE", types.IntType, types.Int(fsnotify.Write)),
+		cel.Constant("fs.RENAME", types.IntType, types.Int(fsnotify.Rename)),
+		cel.Constant("fs.CHMOD", types.IntType, types.Int(fsnotify.Chmod)),
+
+		// `has` macro and function for checking if an event has specific flags.
+		// Example: op.has(fs.CREATE).
+		// Example: op.has(fs.CREATE, fs.RENAME, fs.REMOVE).
+		cel.Macros(
+			cel.ReceiverVarArgMacro("has", hasVarArgMacro),
+		),
+		cel.Function("@has",
+			cel.Overload("@has_int_int", []*cel.Type{cel.IntType, cel.IntType}, cel.BoolType,
+				cel.BinaryBinding(func(event, flag ref.Val) ref.Val {
+					eventInt, ok := event.(types.Int).Value().(int64)
+					if !ok {
+						return types.NewErr("has: invalid event value")
+					}
+					if eventInt > math.MaxUint32 {
+						return types.NewErr("has: event value out of range")
+					}
+
+					eventValue := fsnotify.Op(eventInt) //nolint:gosec // G115: integer overflow conversion.
+
+					flagInt, ok := flag.(types.Int).Value().(int64)
+					if !ok {
+						return types.NewErr("has: invalid flag value")
+					}
+					if flagInt > math.MaxUint32 {
+						return types.NewErr("has: flag value out of range")
+					}
+
+					flagValue := fsnotify.Op(flagInt) //nolint:gosec // G115: integer overflow conversion.
+
+					return types.Bool(eventValue.Has(flagValue))
+				}),
+			),
+			cel.Overload("@has_int_list_int", []*cel.Type{cel.IntType, cel.ListType(cel.IntType)}, cel.BoolType,
+				cel.BinaryBinding(func(event, flags ref.Val) ref.Val {
+					eventInt, ok := event.(types.Int).Value().(int64)
+					if !ok {
+						return types.NewErr("has: invalid event value")
+					}
+					if eventInt > math.MaxUint32 {
+						return types.NewErr("has: event value out of range")
+					}
+
+					eventValue := fsnotify.Op(eventInt) //nolint:gosec // G115: integer overflow conversion.
+
+					flagsList, ok := flags.(traits.Lister)
+					if !ok {
+						return types.NewErr("has: invalid flags list")
+					}
+
+					flagSize, ok := flagsList.Size().(types.Int)
+					if !ok {
+						return types.NewErr("has: invalid flags list size")
+					}
+
+					// Check if the event has any of the specified flags.
+					var mask int64
+					for i := range flagSize {
+						flagVal := flagsList.Get(i)
+						flagInt, ok := flagVal.(types.Int).Value().(int64)
+						if !ok {
+							return types.NewErr("has: invalid flag value in list")
+						}
+
+						mask |= flagInt
+					}
+					if mask > math.MaxUint32 {
+						return types.NewErr("has: flag value out of range")
+					}
+
+					//nolint:gosec // G115: integer overflow conversion.
+					return types.Bool(eventValue.Has(fsnotify.Op(mask)))
+				}),
+			),
+		),
+
+		// `pathBase` returns the last element of the path.
+		// Example: files.filter(f, pathBase(f) in ["Chart.yaml", "values.yaml"]).
+		cel.Function("pathBase",
+			cel.Overload("path_base", []*cel.Type{cel.StringType}, cel.StringType,
+				cel.UnaryBinding(func(path ref.Val) ref.Val {
+					pathValue, ok := path.(types.String).Value().(string)
+					if !ok {
+						return types.NewErr("pathBase: invalid string value")
+					}
+
+					return types.String(filepath.Base(pathValue))
+				}),
+			),
+		),
+
+		// `pathDir` returns all but the last element of the path.
+		// Example: files.filter(f, pathDir(f).contains("/templates/")).
+		cel.Function("pathDir",
+			cel.Overload("path_dir", []*cel.Type{cel.StringType}, cel.StringType,
+				cel.UnaryBinding(func(path ref.Val) ref.Val {
+					pathValue, ok := path.(types.String).Value().(string)
+					if !ok {
+						return types.NewErr("pathDir: invalid string value")
+					}
+
+					return types.String(filepath.Dir(pathValue))
+				}),
+			),
+		),
+
+		// `pathExt` returns the file extension of the path.
+		// Example: files.filter(f, pathExt(f) in [".yaml", ".yml"]).
+		cel.Function("pathExt",
+			cel.Overload("path_ext", []*cel.Type{cel.StringType}, cel.StringType,
+				cel.UnaryBinding(func(path ref.Val) ref.Val {
+					pathValue, ok := path.(types.String).Value().(string)
+					if !ok {
+						return types.NewErr("pathExt: invalid string value")
+					}
+
+					return types.String(filepath.Ext(pathValue))
+				}),
+			),
+		),
+
+		// `yamlPath` reads a YAML file and extracts a value using a YAML path.
+		// Returns the value at the specified path, or null if the path doesn't exist or file can't be read.
+		// Example: files.filter(f, pathBase(f) == "Chart.yaml" && yamlPath(f, "$.apiVersion") == "v2").
+		cel.Function("yamlPath",
+			cel.Overload("yaml_path", []*cel.Type{cel.StringType, cel.StringType}, cel.DynType,
+				cel.BinaryBinding(func(filePath, yamlPathExpr ref.Val) ref.Val {
+					filePathStr, ok := filePath.(types.String).Value().(string)
+					if !ok {
+						return types.NewErr("yamlPath: invalid file path")
+					}
+
+					yamlPathStr, ok := yamlPathExpr.(types.String).Value().(string)
+					if !ok {
+						return types.NewErr("yamlPath: invalid yaml path")
+					}
+
+					logger := slog.With(
+						slog.String("file", filePathStr),
+						slog.String("yamlPath", yamlPathStr),
+					)
+
+					// Read file content.
+					//nolint:gosec // G304: Potential file inclusion via variable.
+					content, err := os.ReadFile(filePathStr)
+					if err != nil {
+						// Return null if file can't be read, don't error.
+						logger.Debug("failed to read YAML file, returning null",
+							slog.Any("error", err),
+						)
+
+						return types.NullValue
+					}
+
+					// Parse YAML path.
+					path, err := yaml.PathString(yamlPathStr)
+					if err != nil {
+						// Return null if path is invalid.
+						logger.Debug("invalid YAML path, returning null",
+							slog.Any("error", err),
+						)
+
+						return types.NullValue
+					}
+
+					// Extract value using YAML path.
+					var value any
+
+					err = path.Read(strings.NewReader(string(content)), &value)
+					if err != nil {
+						// Return null if path doesn't exist or extraction fails.
+						logger.Debug("failed to extract value from YAML, returning null",
+							slog.Any("error", err),
+						)
+
+						return types.NullValue
+					}
+
+					// Convert the extracted value to a CEL value.
+					return ConvertToCELValue(value)
+				}),
+			),
+		),
+	}
+}
+
+func (lib) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}
+
+//nolint:ireturn // Following CEL's function signature.
+func hasVarArgMacro(meh cel.MacroExprFactory, target ast.Expr, args []ast.Expr) (ast.Expr, *cel.Error) {
+	switch len(args) {
+	case 0:
+		return nil, meh.NewError(target.ID(), "has() requires at least one argument")
+	case 1:
+		return meh.NewCall("@has", target, args[0]), nil
+	default:
+		return meh.NewCall("@has", target, meh.NewList(args...)), nil
+	}
+}
+
+// ConvertToCELValue converts a Go value to a CEL value.
+// Handles common YAML types and returns null for unsupported types.
+//
+//nolint:ireturn // Following CEL's function signature.
+func ConvertToCELValue(value any) ref.Val {
+	switch v := value.(type) {
+	case nil:
+		return types.NullValue
+
+	case bool:
+		return types.Bool(v)
+
+	case int:
+		return types.Int(v)
+
+	case int8:
+		return types.Int(int64(v))
+
+	case int16:
+		return types.Int(int64(v))
+
+	case int32:
+		return types.Int(int64(v))
+
+	case int64:
+		return types.Int(v)
+
+	case uint:
+		// Check for overflow when converting to int64.
+		if v > math.MaxInt64 {
+			return types.Double(float64(v))
+		}
+
+		return types.Int(int64(v))
+
+	case uint8:
+		return types.Int(int64(v))
+
+	case uint16:
+		return types.Int(int64(v))
+
+	case uint32:
+		return types.Int(int64(v))
+
+	case uint64:
+		// Check for overflow when converting to int64.
+		if v > math.MaxInt64 {
+			return types.Double(float64(v))
+		}
+
+		return types.Int(int64(v))
+
+	case float32:
+		return types.Double(float64(v))
+
+	case float64:
+		return types.Double(v)
+
+	case string:
+		return types.String(v)
+
+	case []any:
+		// Convert slice to CEL list.
+		celValues := make([]ref.Val, len(v))
+		for i, item := range v {
+			celValues[i] = ConvertToCELValue(item)
+		}
+
+		return types.NewDynamicList(types.DefaultTypeAdapter, celValues)
+
+	case map[any]any:
+		// Convert map to CEL map.
+		celMap := make(map[ref.Val]ref.Val)
+		for key, val := range v {
+			celKey := ConvertToCELValue(key)
+			celVal := ConvertToCELValue(val)
+			celMap[celKey] = celVal
+		}
+
+		return types.NewDynamicMap(types.DefaultTypeAdapter, celMap)
+
+	case map[string]any:
+		// Convert string map to CEL map.
+		celMap := make(map[ref.Val]ref.Val)
+		for key, val := range v {
+			celKey := types.String(key)
+			celVal := ConvertToCELValue(val)
+			celMap[celKey] = celVal
+		}
+
+		return types.NewDynamicMap(types.DefaultTypeAdapter, celMap)
+
+	default:
+		// For unsupported types, return null instead of erroring.
+		return types.NullValue
+	}
+}

--- a/pkg/profile/status.go
+++ b/pkg/profile/status.go
@@ -1,0 +1,112 @@
+package profile
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+)
+
+type (
+	// RenderStage represents the different stages of rendering.
+	// It is used to track the progress of rendering operations.
+	RenderStage int
+
+	// RenderResult represents the result of a rendering operation.
+	RenderResult string
+)
+
+const (
+	// StageNone indicates no rendering is active.
+	StageNone RenderStage = iota
+	// StageInit is the initial stage of rendering. Not currently implemented.
+	StageInit
+	// StagePreRender is the stage before the main rendering command.
+	StagePreRender
+	// StageRender is the main rendering stage where the command is executed.
+	StageRender
+	// StagePostRender is the stage after the main rendering command.
+	StagePostRender
+
+	// ResultOK indicates the rendering was successful.
+	ResultOK RenderResult = "OK"
+	// ResultError indicates there was an error during rendering.
+	ResultError RenderResult = "ERROR"
+	// ResultCancel indicates the rendering was canceled.
+	ResultCancel RenderResult = "CANCEL"
+	// ResultNone indicates no rendering result is available.
+	ResultNone RenderResult = ""
+)
+
+type Status struct {
+	renderResult RenderResult
+	renderStage  RenderStage
+	mu           sync.Mutex
+}
+
+func (s *Status) SetStage(stage RenderStage) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.renderStage = stage
+}
+
+func (s *Status) SetResult(result RenderResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.renderStage = StageNone
+	s.renderResult = result
+}
+
+func (s *Status) SetError(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.renderStage = StageNone
+
+	if errors.Is(ctx.Err(), context.Canceled) {
+		s.renderResult = ResultCancel
+	} else {
+		s.renderResult = ResultError
+	}
+}
+
+// RenderMap returns a map of render values exposed to CEL.
+func (s *Status) RenderMap() map[string]any {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return map[string]any{
+		"stage":  int(s.renderStage),
+		"result": string(s.renderResult),
+	}
+}
+
+type renderLib struct{}
+
+func RenderLib() cel.EnvOption {
+	return cel.Lib(renderLib{})
+}
+
+func (renderLib) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Variable("render", cel.MapType(cel.StringType, cel.DynType)),
+
+		cel.Constant("render.STAGE_NONE", cel.IntType, types.Int(StageNone)),
+		cel.Constant("render.STAGE_PRE_RENDER", cel.IntType, types.Int(StagePreRender)),
+		cel.Constant("render.STAGE_RENDER", cel.IntType, types.Int(StageRender)),
+		cel.Constant("render.STAGE_POST_RENDER", cel.IntType, types.Int(StagePostRender)),
+
+		cel.Constant("render.RESULT_NONE", cel.StringType, types.String(string(ResultNone))),
+		cel.Constant("render.RESULT_OK", cel.StringType, types.String(string(ResultOK))),
+		cel.Constant("render.RESULT_CANCEL", cel.StringType, types.String(string(ResultCancel))),
+		cel.Constant("render.RESULT_ERROR", cel.StringType, types.String(string(ResultError))),
+	}
+}
+
+func (renderLib) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -72,7 +72,15 @@ func MustNew(profileName, match string) *Rule {
 // CompileMatch compiles the rule's match expression into a CEL program.
 func (r *Rule) CompileMatch() error {
 	if r.matchProgram == nil {
-		program, err := expr.DefaultEnvironment.Compile(r.Match)
+		env, err := expr.NewEnvironment(
+			cel.Variable("files", cel.ListType(cel.StringType)),
+			cel.Variable("dir", cel.StringType),
+		)
+		if err != nil {
+			return fmt.Errorf("create CEL environment: %w", err)
+		}
+
+		program, err := env.Compile(r.Match)
 		if err != nil {
 			return fmt.Errorf("compile match expression: %w", err)
 		}


### PR DESCRIPTION
ref: #84 

This PR adds a new `reload` field to profiles that allows users to filter reload events using CEL expressions:

```yaml
profiles:
  helm:
    command: helm
    args: [template, .]
    source: >-
      files.filter(f, pathExt(f) in [".yaml", ".yml", ".tpl"])
    reload: >-
      fs.event.has(fs.WRITE) &&
      render.stage < render.STAGE_POST_RENDER &&
      render.result != render.RESULT_CANCEL
```

If no `reload` expression is provided, profiles will continue to work as before (reloading on all events). Note: existing path functions are also available.

### New CEL EnvOptions

New CEL functions and constants are available for these expressions.

**File System Variables**:
- `file` - The subject of the event.
- `fs.event` - The triggering file system event.

**File System Functions**:
- `has(event, flag...)`: Check if file system events contain specific flags

**File System Constants**:
- `fs.CREATE`, `fs.WRITE`, `fs.REMOVE`, `fs.RENAME`, `fs.CHMOD`: Event type constants

**Render Status Variables**:
- `render.stage` - The current render stage.
- `render.result` - The last render result.

**Render Status Constants**:
- `render.STAGE_*`: Track current render stage (NONE, PRE_RENDER, RENDER, POST_RENDER)
- `render.RESULT_*`: Track last render result (NONE, OK, ERROR, CANCEL)

### Example Use Cases

```yaml
# Skip reloads for certain files
reload: >-
  pathBase(file) != "kustomization.yaml"

# Only reload on write events
reload: >-
  fs.event.has(fs.WRITE)

# Prevent reloads during active rendering
reload: >-
  render.stage < render.STAGE_RENDER

# Skip reloads if last operation was canceled
reload: >-
  render.result != render.RESULT_CANCEL
```