### PR TITLE
feat: point to published schema instead of writing a local file

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -308,17 +308,6 @@ func WriteDefaultConfig(path string, force bool) error {
 		)
 	}
 
-	// Write the JSON schema file alongside the config file.
-	schemaPath := filepath.Join(filepath.Dir(path), "config.v1beta1.json")
-	slog.Debug("write JSON schema",
-		slog.String("path", schemaPath),
-	)
-
-	err = os.WriteFile(schemaPath, schemaJSON, 0o600)
-	if err != nil {
-		return fmt.Errorf("write schema file: %w", err)
-	}
-
 	return nil
 }
 

--- a/pkg/config/config.yaml
+++ b/pkg/config/config.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=./config.v1beta1.json
+# yaml-language-server: $schema=https://jacobcolvin.com/kat/schemas/config.v1beta1.json
 apiVersion: kat.jacobcolvin.com/v1beta1
 kind: Configuration
 


### PR DESCRIPTION
The local JSON schema file is no longer written alongside the config, and the YAML configuration now references a remote schema URL instead of a local file. Internal validation still uses embedded data.

Related to #89